### PR TITLE
Compose extension

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,23 +2,24 @@ version: '3.9'
 
 services:
   app:
-    image: ghcr.io/remla25-team12/app:latest
+    image: ghcr.io/remla25-team12/app:${APP_TAG-latest}
     container_name: app
-    # environment:
-    #   - ENV_VAR=<tbd>
-    # volumes:
-    #   - <tbd>
+    env_file:
+      - versions.env
     ports:
       - 8080:8080
     restart: unless-stopped
     
   model-service:
-    image: ghcr.io/remla25-team12/model-service:latest
+    image: ghcr.io/remla25-team12/model-service:${TAG_MODEL_SERVICE-latest}
     container_name: model-service
+    env_file:
+      - versions.env
+    volumes:
+      ### syntax: path/to/local/dir:path/to/docker/dir
+    #  - ./:/root/
     # environment:
     #   - ENV_VAR=<tbd>
     #   - Pass model url as env? 
-    # volumes:
-    #   - <tbd>
     restart: unless-stopped
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,25 +1,22 @@
-version: '3.9'
-
 services:
   app:
-    image: ghcr.io/remla25-team12/app:${APP_TAG-latest}
+    image: ghcr.io/remla25-team12/app:${TAG_APP-latest}
     container_name: app
-    env_file:
-      - versions.env
+    volumes:
+      - ../app:/app # assuming docker-compose is executed inside the operation folder, which is placed alongside the app folder
     ports:
-      - 8080:8080
+      - 5000:5000 
+    # depends-on:
+    #   - model-service # to ensure the model loads before the web app
     restart: unless-stopped
     
-  model-service:
-    image: ghcr.io/remla25-team12/model-service:${TAG_MODEL_SERVICE-latest}
-    container_name: model-service
-    env_file:
-      - versions.env
-    volumes:
-      ### syntax: path/to/local/dir:path/to/docker/dir
-    #  - ./:/root/
+  #model-service:
+    #image: ghcr.io/remla25-team12/model-service:$(TAG_MODEL_SERVICE-latest)
+    #container_name: model-service
     # environment:
     #   - ENV_VAR=<tbd>
     #   - Pass model url as env? 
-    restart: unless-stopped
+    # volumes:
+    #   - <tbd>
+    #restart: unless-stopped
 

--- a/versions.env
+++ b/versions.env
@@ -1,0 +1,2 @@
+TAG_APP = latest
+TAG_MODEL_SERVICE = latest

--- a/versions.env
+++ b/versions.env
@@ -1,2 +1,2 @@
-TAG_APP = latest
+TAG_APP = 0.2.0
 TAG_MODEL_SERVICE = latest


### PR DESCRIPTION
docker-compose.yaml can now pull and launch the app from ghcr.
Use the .env file to specify the version of the container.
The config for model-service is commented away for now.