### PR TITLE
Add installation of k8s tools to general.yaml

### DIFF
--- a/provisioning/general.yaml
+++ b/provisioning/general.yaml
@@ -47,7 +47,6 @@
         name: br_netfilter
         state: present
 
-
     # Step 7: 
     - name: Enable IPv4 port forwarding kernel property
       ansible.posix.sysctl:
@@ -99,13 +98,28 @@
       ansible.builtin.apt:
         update_cache: yes
     
+    # Step 10: Install K8s tools
+    - name: Install containerd and runc
+      ansible.builtin.apt:
+        name:
+          - containerd=1.7.24-0ubuntu1~24.04.2
+          - runc=1.1.12-0ubuntu3.1
+        state: present
+        update_cache: yes
+
+    - name: Install Kubernetes tools
+      ansible.builtin.apt:
+        name:
+          - kubeadm=1.32.4-1.1
+          - kubelet=1.32.4-1.1
+          - kubectl=1.32.4-1.1
+        state: present
 
     # Step 11: Configure containerd
     - name: Generate default containerd file
       ansible.builtin.command: containerd config default
       register: containerd_config_default
       changed_when: false
- 
  
     - name: Ensure "/etc/containerd" directory exists
       ansible.builtin.file:
@@ -131,14 +145,12 @@
         line: '\1disable_apparmor = true'
         backrefs: yes
  
- 
     - name: Update version of the sandbox image
       ansible.builtin.lineinfile:
         path: /etc/containerd/config.toml
         regexp: '^(\s*)sandbox_image\s*=.*'
         line: '\1sandbox_image = "registry.k8s.io/pause:3.10"'
         backrefs: yes
- 
  
     - name: Set SystemdCgroup to true
       ansible.builtin.lineinfile:
@@ -147,11 +159,8 @@
         line: '\1SystemdCgroup = true'
         backrefs: yes
  
- 
     - name: Restart containerd service
       ansible.builtin.service:
         name: containerd
         state: restarted
         enabled: yes
- 
- 


### PR DESCRIPTION
Step 10 from the document is implemented:
- Containerd, runc, and basic Kubernetes tools kubeadm , kubelet , and kubectl are installed automatically with correct versions.