### PR TITLE
Refactor Vagrantfile to use a function for VM setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,11 +36,11 @@ def vm_setup(vm, name:, ip:, memory:, cpus:, playbook:)
 
   # Provision with node-specific playbook (Step 3)
   # (ctrl.yaml for controller, node.yaml for worker nodes)
-  # vm.vm.provision "ansible" do |ansible|
-  #   ansible.compatibility_mode = "2.0"
-  #   ansible.playbook = playbook
-  #   ansible.vault_password_file = "~/.vault_pass.txt"
-  # end
+  vm.vm.provision "ansible" do |ansible|
+    ansible.compatibility_mode = "2.0"
+    ansible.playbook = playbook
+    ansible.vault_password_file = "~/.vault_pass.txt"
+  end
 end
 
 


### PR DESCRIPTION
I refactored the Vagrantfile such that the VMs (controller and nodes) are set up through a function.
I also added variables for the amount of memory and number of cpu's for each node, as per the excellent rubric requirements.

The Vagrantfile works 100% on my machine, but feel free to test before merging.
Note that you need to comment away line 39 to 43 to avoid the errors caused by the currently incomplete ctrl.yaml and node.yaml.
