### PR TITLE
Idempotency improvements with kubernetes.core ansible collectoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This repository serves as the central point of the project, containing the Docke
     git clone https://github.com/remla25-team12/operation.git
    ```
 
-2. Navigate into the repository's root folder and install the required Ansible components:
+2. Navigate into the repository's root folder and install the required Ansible collections:
    ```bash
    ansible-galaxy collection install -r requirements.yml 
    ```

--- a/README.md
+++ b/README.md
@@ -56,12 +56,17 @@ This repository serves as the central point of the project, containing the Docke
     git clone https://github.com/remla25-team12/operation.git
    ```
 
-2. Before continuing, it is important to reset the host-only networks in VirtualBox. This prevents conflicts with stale or broken network configurations from previous VirtualBox setups.
+2. Navigate into the repository's root folder and install the required Ansible components:
+   ```bash
+   ansible-galaxy collection install -r requirements.yml 
+   ```
+
+3. Before continuing, it is important to reset the host-only networks in VirtualBox. This prevents conflicts with stale or broken network configurations from previous VirtualBox setups.
 To do this, **open the VirtualBox GUI**, go to `Tools > Network`, and **remove any existing "Host-only Networks"** listed under that section. The list should now be empty:
 ![Empty host-only adapter list](imgs/vb_empty.png)
 
 
-2. Start the virtual environment from the repository's root folder:
+4. Start the virtual environment from the repository's root folder:
 
    ```bash
     cd operation
@@ -69,13 +74,13 @@ To do this, **open the VirtualBox GUI**, go to `Tools > Network`, and **remove a
    ```
    This operation may take a while to complete.
 
-4. Once the VMs are up and provisioned, run the following Ansible playbook to finalize the Kubernetes setup:
+5. Once the VMs are up and provisioned, run the following Ansible playbook to finalize the Kubernetes setup:
 
    ```bash
     ansible-playbook -u vagrant -i 192.168.56.100, provisioning/finalization.yml
    ```
 
-5. To access the Kubernetes dashboard, do the following **on your host machine**:
+6. To access the Kubernetes dashboard, do the following **on your host machine**:
 
    - Edit the `/etc/hosts` file to resolve https://dashboard.local, by adding the following line to the file: 
    ```plaintext
@@ -88,7 +93,7 @@ To do this, **open the VirtualBox GUI**, go to `Tools > Network`, and **remove a
 
    > **Note**: The token is generated in the previous step. If you cannot find the token in the terminal output, run `vagrant ssh ctrl`, followed by `kubectl -n kubernetes-dashboard create token admin-user` to generate a new one.
 
-6. To communicate with the cluster from the host, a kubeconfig file (`admin.conf`) has been exported by Ansible. For example, you can run:
+7. To communicate with the cluster from the host, a kubeconfig file (`admin.conf`) has been exported by Ansible. For example, you can run:
    ```bash
    kubectl get ns --kubeconfig ./provisioning/admin.conf
    ```

--- a/provisioning/ctrl.yaml
+++ b/provisioning/ctrl.yaml
@@ -2,8 +2,44 @@
   hosts: ctrl
   become: yes
   gather_facts: yes
+  vars:
+    venv_path: /opt/ansible-venv
 
   tasks:
+    # intermezzo: create venv for kubernetes.core ansible
+    - name: Set up venv for kubernetes.core
+      become_user: root
+      block:
+      - name: Ensure Python venv module is installed
+        ansible.builtin.package:
+          name: python3-venv
+          state: present
+        
+      - name: Create virtual environment
+        ansible.builtin.command: python3 -m venv --upgrade {{ venv_path }}
+        args:
+          creates: "{{ venv_path }}/bin/activate"
+
+      - name: Upgrade pip
+        pip: 
+          name: pip
+          state: latest
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: python3 -m venv
+
+      - name: Upgrade setuptools
+        pip: 
+          name: setuptools
+          state: latest
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: python3 -m venv
+
+      - name: Install kubernetes client in venv
+        ansible.builtin.pip:
+          name: kubernetes
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: python3 -m venv
+
     # Step 13: Init cluster
     - name: Check if kubernetes is already initialized
       stat:
@@ -42,7 +78,6 @@
         src: /etc/kubernetes/admin.conf
         dest: ./
         flat: yes
-      #when: not kube_config.stat.exists
 
     # Step 15: Create Pod network
     - name: Download Flannel config
@@ -57,10 +92,12 @@
         replace: 'args:\n        - --iface=eth1\n\1'
 
     - name: Apply Flannel network 
-      command: kubectl apply -f /tmp/kube-flannel.yml
       become_user: vagrant
-      # environment:
-      #   KUBECONFIG: /home/vagrant/.kube/config
+      kubernetes.core.k8s:
+        state: present
+        src: "/tmp/kube-flannel.yml"
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
     # Step 16: Install Helm
     - name: Add Helm GPG key

--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -4,6 +4,7 @@
   become: yes
   become_user: vagrant
   vars:
+    venv_path: /opt/ansible-venv
     dashboard_admin_yaml: | 
       apiVersion: v1
       kind: ServiceAccount
@@ -49,21 +50,66 @@
                         number: 443
 
   tasks:
-    # Step 20: Install MetalLB
+    # intermezzo: create venv for kubernetes.core ansible
+    # TODO: move entire block to general.yaml or ctrl.yaml since we need it for flannel
+    - name: Set up venv for kubernetes.core
+      become_user: root
+      block:
+      - name: Ensure Python venv module is installed
+        ansible.builtin.package:
+          name: python3-venv
+          state: present
+        
+      - name: Create virtual environment
+        ansible.builtin.command: python3 -m venv --upgrade {{ venv_path }}
+        args:
+          creates: "{{ venv_path }}/bin/activate"
+
+      - name: Upgrade pip
+        pip: 
+          name: pip
+          state: latest
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: python3 -m venv
+
+      - name: Upgrade setuptools
+        pip: 
+          name: setuptools
+          state: latest
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: python3 -m venv
+
+      - name: Install kubernetes client in venv
+        ansible.builtin.pip:
+          name: kubernetes
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: python3 -m venv
+
+    # Step 20 - Install MetalLB
     - name: Download MetalLB yaml file
       get_url:
         url: https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
         dest: "/tmp/metallb-native.yaml"
 
     - name: Apply MetalLB CRDs
-      shell: kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
+      kubernetes.core.k8s:
+        state: present
+        src: "/tmp/metallb-native.yaml"
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
-    - name: Wait for MetalLB controller pod to be ready
-      shell: >
-        kubectl wait -n metallb-system 
-        -l app=metallb,component=controller
-        --for=condition=ready pod 
-        --timeout=300s
+    - name: Waiting for MetalLB controller pod to be ready
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: true
+        namespace: metallb-system
+        label_selectors:
+          - app=metallb
+          - component=controller
+        wait_sleep: 5
+        wait_timeout: 150
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
     - name: Configure IPAddressPool
       copy:
@@ -79,7 +125,12 @@
               - 192.168.56.90-192.168.56.99
 
     - name: Apply IPAddressPool
-      command: kubectl apply -f /tmp/metallb-pool.yaml
+      # command: kubectl apply -f /tmp/metallb-pool.yaml
+      kubernetes.core.k8s:
+        state: present
+        src: "/tmp/metallb-pool.yaml"
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
     - name: Configure L2Advertisement
       copy:
@@ -93,7 +144,12 @@
           spec: {}
 
     - name: Apply L2Advertisement
-      command: kubectl apply -f /tmp/metallb-l2.yaml
+      #command: kubectl apply -f /tmp/metallb-l2.yaml
+      kubernetes.core.k8s:
+        state: present
+        src: "/tmp/metallb-l2.yaml"
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
     # Step 21: Install Nginx Ingress Controller
     - name: "Add Nginx Ingress repository"
@@ -114,13 +170,6 @@
             service:
               loadBalancerIP: 192.168.56.91
 
-    # - name: Wait for ingress-nginx controller to be ready
-    #   shell: >
-    #     kubectl wait -n ingress-nginx 
-    #     -l app.kubernetes.io/component=controller 
-    #     --for=condition=ready pod 
-    #     --timeout=60s
-
     # Step 22: Install Kubernetes Dashboard
     - name: "Add Kubernetes dashboard repository"
       kubernetes.core.helm_repository:
@@ -130,7 +179,7 @@
 
     - name: "Install Kubernetes dashboard chart"
       kubernetes.core.helm:
-        name: "kubernetes-dashboard"
+        name: kubernetes-dashboard
         chart_ref: "kubernetes-dashboard/kubernetes-dashboard"
         release_namespace: kubernetes-dashboard 
         create_namespace: yes        
@@ -142,19 +191,42 @@
         content: "{{ dashboard_admin_yaml }}"
           
     - name: Apply admin user config
-      command: kubectl apply -f /tmp/dashboard-admin.yaml
+      # command: kubectl apply -f /tmp/dashboard-admin.yaml
+      kubernetes.core.k8s:
+        state: present
+        src: "/tmp/dashboard-admin.yaml"
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
     - name: Create dashboard Ingress
       copy:
         dest: /tmp/dashboard-ingress.yaml
         content: "{{ dashboard_ingress_yaml }}"
 
+    - name: Waiting for dashboard ingress to be ready
+      kubernetes.core.k8s_info:
+        kind: Pod
+        wait: true
+        namespace: ingress-nginx
+        label_selectors:
+          - app.kubernetes.io/component=controller
+        wait_sleep: 5
+        wait_timeout: 150
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
+
     - name: Apply dashboard ingress
-      command: kubectl apply -f /tmp/dashboard-ingress.yaml
+      # command: kubectl apply -f /tmp/dashboard-ingress.yaml
+      kubernetes.core.k8s:
+        state: present
+        src: "/tmp/dashboard-ingress.yaml"
+      vars:
+        ansible_python_interpreter: "{{ venv_path }}/bin/python"
 
     - name: Generate dashboard admin token
       command: kubectl -n kubernetes-dashboard create token admin-user
       register: dashboard_token
+      changed_when: false
 
     - name: Show dashboard login token and next steps
       debug:

--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -5,6 +5,7 @@
   become_user: vagrant
   vars:
     venv_path: /opt/ansible-venv
+    ansible_python_interpreter: "{{ venv_path }}/bin/python"
     dashboard_admin_yaml: | 
       apiVersion: v1
       kind: ServiceAccount
@@ -50,41 +51,6 @@
                         number: 443
 
   tasks:
-    # intermezzo: create venv for kubernetes.core ansible
-    # TODO: move entire block to general.yaml or ctrl.yaml since we need it for flannel
-    - name: Set up venv for kubernetes.core
-      become_user: root
-      block:
-      - name: Ensure Python venv module is installed
-        ansible.builtin.package:
-          name: python3-venv
-          state: present
-        
-      - name: Create virtual environment
-        ansible.builtin.command: python3 -m venv --upgrade {{ venv_path }}
-        args:
-          creates: "{{ venv_path }}/bin/activate"
-
-      - name: Upgrade pip
-        pip: 
-          name: pip
-          state: latest
-          virtualenv: "{{ venv_path }}"
-          virtualenv_command: python3 -m venv
-
-      - name: Upgrade setuptools
-        pip: 
-          name: setuptools
-          state: latest
-          virtualenv: "{{ venv_path }}"
-          virtualenv_command: python3 -m venv
-
-      - name: Install kubernetes client in venv
-        ansible.builtin.pip:
-          name: kubernetes
-          virtualenv: "{{ venv_path }}"
-          virtualenv_command: python3 -m venv
-
     # Step 20 - Install MetalLB
     - name: Download MetalLB yaml file
       get_url:
@@ -95,9 +61,7 @@
       kubernetes.core.k8s:
         state: present
         src: "/tmp/metallb-native.yaml"
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+     
     - name: Waiting for MetalLB controller pod to be ready
       kubernetes.core.k8s_info:
         kind: Pod
@@ -108,9 +72,7 @@
           - component=controller
         wait_sleep: 5
         wait_timeout: 150
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+      
     - name: Configure IPAddressPool
       copy:
         dest: /tmp/metallb-pool.yaml
@@ -125,13 +87,10 @@
               - 192.168.56.90-192.168.56.99
 
     - name: Apply IPAddressPool
-      # command: kubectl apply -f /tmp/metallb-pool.yaml
       kubernetes.core.k8s:
         state: present
         src: "/tmp/metallb-pool.yaml"
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+     
     - name: Configure L2Advertisement
       copy:
         dest: /tmp/metallb-l2.yaml
@@ -144,13 +103,10 @@
           spec: {}
 
     - name: Apply L2Advertisement
-      #command: kubectl apply -f /tmp/metallb-l2.yaml
       kubernetes.core.k8s:
         state: present
         src: "/tmp/metallb-l2.yaml"
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+      
     # Step 21: Install Nginx Ingress Controller
     - name: "Add Nginx Ingress repository"
       kubernetes.core.helm_repository:
@@ -191,13 +147,10 @@
         content: "{{ dashboard_admin_yaml }}"
           
     - name: Apply admin user config
-      # command: kubectl apply -f /tmp/dashboard-admin.yaml
       kubernetes.core.k8s:
         state: present
         src: "/tmp/dashboard-admin.yaml"
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+      
     - name: Create dashboard Ingress
       copy:
         dest: /tmp/dashboard-ingress.yaml
@@ -212,17 +165,12 @@
           - app.kubernetes.io/component=controller
         wait_sleep: 5
         wait_timeout: 150
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+      
     - name: Apply dashboard ingress
-      # command: kubectl apply -f /tmp/dashboard-ingress.yaml
       kubernetes.core.k8s:
         state: present
         src: "/tmp/dashboard-ingress.yaml"
-      vars:
-        ansible_python_interpreter: "{{ venv_path }}/bin/python"
-
+      
     - name: Generate dashboard admin token
       command: kubectl -n kubernetes-dashboard create token admin-user
       register: dashboard_token

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,4 @@
 
 collections:
   - name: community.general
+  - name: kubernetes.core


### PR DESCRIPTION
I added the kubernetes.core ansible collection to requirements.txt and replaced most shell commands (e.g. shell: "kubectl apply -f *.yaml") with components such as kubernetes.core.k8s. 

You need to run 'ansible-galaxy collection install -r requirements.yml' once before being able to run these playbooks now. I added this to the README install instructions too.

The whole deployment should now be 100% idempotent.
However, two tasks in finalization.yaml sometimes bug out for me and still show [changed]. I don't know why, they use the exact same commands as other apply and install tasks. The tasks are:
- "Apply MetalLB CRDs"
- "Install Kubernetes dashboard chart". 

