### PR TITLE
Model service port is made configurable via .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 # last known working & compatible versions
-TAG_APP=0.3.3
-TAG_MODEL_SERVICE=1.1.1
+TAG_APP=0.4.4
+TAG_MODEL_SERVICE=1.1.6
+MODEL_SERVICE_PORT=5055

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,18 +4,19 @@ services:
     #image: ms-test:latest # local build, only for testing purposes
     container_name: model-service
     env_file: .env
-    # ports:
-    #   - 5000:5000  # only expose this port during debugging/testing
+    ports:
+      - "${MODEL_SERVICE_PORT:-5000}:${MODEL_SERVICE_PORT:-5000}"
     environment:
       - MODEL_URL=https://github.com/remla25-team12/model-training/releases/download/v0.1.0/Classifier_Sentiment_Model.joblib # model URL
       - VEC_URL=https://github.com/remla25-team12/model-training/releases/download/v0.1.0/c1_BoW_Sentiment_Model.pkl # vectorizer URL
       - MODEL_CACHE_DIR=/app/cache
       - FEEDBACK_FILE_PATH=/app/feedback/feedback_dump.tsv
+      - MODEL_SERVICE_PORT=${MODEL_SERVICE_PORT}
     # volumes:
     # - ./Classifier_Sentiment_Model.joblib:/app/Classifier_Sentiment_Model.joblib # local pre-downloaded model (prevent re-downloading)
     volumes:
       - cache:/app/cache # cache for downloaded models
-      - ./feedback:/app/feedback 
+      - ./feedback:/app/feedback
     networks:
       - backend
     restart: unless-stopped
@@ -28,9 +29,9 @@ services:
     ports:
       - 8080:5000
     environment:
-      - MODEL_SERVICE_URL=http://model-service:5000/predict
-      - NEW_DATA_URL=http://model-service:5000/new_data
-      - VERSION_URL=http://model-service:5000/version
+      - MODEL_SERVICE_URL=http://model-service:${MODEL_SERVICE_PORT}/predict
+      - NEW_DATA_URL=http://model-service:${MODEL_SERVICE_PORT}/new_data
+      - VERSION_URL=http://model-service:${MODEL_SERVICE_PORT}/version
     networks:
       - backend
     restart: unless-stopped

--- a/feedback/feedback_dump.tsv
+++ b/feedback/feedback_dump.tsv
@@ -1,0 +1,2 @@
+Review	Liked
+I hated this restraunt	0


### PR DESCRIPTION
- The listening port of the model-service is made configured through an ENV variable (A1 requirement).

Note: When checking this MR, please also check the port number declaration in model_service.py file under Model Service repo. Also, please run the "docker compose up" command to test.