### PR TITLE
Shorten myprom installation command

### DIFF
--- a/helm/myapp/values-myprom.yaml
+++ b/helm/myapp/values-myprom.yaml
@@ -1,0 +1,9 @@
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    configSecret: myapp-dev-alertmanager-config
+grafana:
+  enabled: true
+prometheus:
+  prometheusSpec:
+    maximumStartupDurationSeconds: 120

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -49,8 +49,6 @@ gateways:
     type: LoadBalancer
     externalTrafficPolicy: Local
 
-
-
 useHostPathSharedFolder: true
 
 #secrets:


### PR DESCRIPTION
(ignore the name of the branch, a child chart under our helm chart wasn't possible)

Our custom AlertManager configuration required a handful of manual overrides of the default myprom chart.
For readability of the install command, I put these in a separate file: helm/myapp/values-myprom.yaml

I also edited the README accordingly, and added additional bold sentences below section headers to make it extra clear when you should be running what command and where (host or ctrl, VM or Minikube, etc etc)

Closes #94 