### PR TITLE
Finalize Minikube Setup with README Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ To access the deployed application, you need to be able to resolve `myapp.local`
       minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
       ```
 
+ > **Note:** Make sure that you have only one instance of `myapp.local` on your `/etc/hosts` file (either for VM Cluster or Minikube). 
+
 Then access the application at http://myapp.local
 
 Metrics are available at http://myapp.local/metrics

--- a/README.md
+++ b/README.md
@@ -261,21 +261,21 @@ To access the deployed application, you need to be able to resolve `myapp.local`
 
   1. Resolve `myapp.local`:
 
-   ```bash
-   sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
-   ```
+      ```shell
+      sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
+      ```
 
   2. Make sure that requests to `myapp.local` are not intercepted by nginx before tunneling. To ensure nginx is not listening on port 80, you can stop local nginx temporarily:
 
-   ```bash
-   sudo nginx -s stop
-   ```
+      ```shell
+      sudo nginx -s stop
+      ```
 
   3. Finally, Minikube tunnel:
 
-   ```bash
-   minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
-   ```
+      ```shell
+      minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
+      ```
 
 Then access the application at http://myapp.local
 

--- a/README.md
+++ b/README.md
@@ -261,21 +261,21 @@ To access the deployed application, you need to be able to resolve `myapp.local`
 
   1. Resolve `myapp.local`:
 
-  ```bash
-  sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
-  ```
+   ```bash
+   sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
+   ```
 
   2. Make sure that requests to `myapp.local` are not intercepted by nginx before tunneling. To ensure nginx is not listening on port 80, you can stop local nginx temporarily:
 
-  ```bash
-  sudo nginx -s stop
-  ```
+   ```bash
+   sudo nginx -s stop
+   ```
 
   3. Finally, Minikube tunnel:
 
-  ```bash
-  minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
-  ```
+   ```bash
+   minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
+   ```
 
 Then access the application at http://myapp.local
 

--- a/README.md
+++ b/README.md
@@ -259,19 +259,19 @@ To access the deployed application, you need to be able to resolve `myapp.local`
 
 - On **Minikube**:
 
-  - Resolve `myapp.local`:
+  1. Resolve `myapp.local`:
 
   ```bash
   sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
   ```
 
-  - Make sure that requests to `myapp.local` are not intercepted by nginx before tunneling. To ensure nginx is not listening on port 80, you can stop local nginx temporarily:
+  2. Make sure that requests to `myapp.local` are not intercepted by nginx before tunneling. To ensure nginx is not listening on port 80, you can stop local nginx temporarily:
 
   ```bash
   sudo nginx -s stop
   ```
 
-  - Finally, Minikube tunnel:
+  3. Finally, Minikube tunnel:
 
   ```bash
   minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local

--- a/README.md
+++ b/README.md
@@ -261,23 +261,19 @@ To access the deployed application, you need to be able to resolve `myapp.local`
 
   1. Resolve `myapp.local`:
 
-      ```shell
-      sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
-      ```
+     ```shell
+     sudo sh -c 'echo "127.0.0.1  myapp.local" >> /etc/hosts'
+     ```
 
-  2. Make sure that requests to `myapp.local` are not intercepted by nginx before tunneling. To ensure nginx is not listening on port 80, you can stop local nginx temporarily:
+  2. Then, Minikube tunnel:
 
-      ```shell
-      sudo nginx -s stop
-      ```
+     ```shell
+     minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
+     ```
 
-  3. Finally, Minikube tunnel:
+  > **Note:** If you receive `Bad gateway` error when accessing the application at `myapp.local` using Minikube, please go to the `Troubleshooting` section to resolve this error.
 
-      ```shell
-      minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
-      ```
-
- > **Note:** Make sure that you have only one instance of `myapp.local` on your `/etc/hosts` file (either for VM Cluster or Minikube). 
+> **Note:** Make sure that you have only one instance of `myapp.local` on your `/etc/hosts` file (either for VM Cluster or Minikube).
 
 Then access the application at http://myapp.local
 
@@ -304,6 +300,8 @@ for i in {1..10}; do curl -s -H "Host: myapp.local" -H "x-newvers: true" -H "x-u
 ```
 
 ## Prometheus, Grafana, Alert Manager, and Rate Limiting
+
+> **Note:** If you face any issues in this section, please check the `Troubleshooting` section.
 
 ### Prometheus
 
@@ -355,7 +353,7 @@ kubectl -n istio-system port-forward "$ALERTMANAGER_POD" 9093:9093
 
 ### Rate Limiting
 
-Rate Limiting is setup to a maximum of 2 requests/min per user (IP) on the `/predict` endpoint. This can be tested by trying to predict 3 different reviews in quick succession. The third request will be rejected with a `429 status code  (Too Many Requests)`.
+Rate Limiting is setup to a maximum of 2 requests/min per user (IP) on the `/predict` endpoint. This can be tested by trying to predict 3 different reviews in quick succession. The third request will be rejected with a `429 status code (Too Many Requests)`.
 
 Additionally, there is a global rate limit of 10 requests/min. This can be tested by refreshing the landing page at least 11 times in quick succession (ctrl+R in the browser). The 11th request will be rejected with a `429 status code (Too Many Requests)`.
 
@@ -374,8 +372,25 @@ This would set the `/predict` endpoint to 10 requests/min per user and the globa
 
 This section lists some backup methods and workarounds for problems that we have encountered. We list them separately to keep the main installation instructions readable.
 
-**Problem**: kubectl does not work from host, only from the ctrl node. Cannot access Prometheus/Grafana.
-**Solution**: Since kubectl still works on ctrl, just use ctrl's IP address instead of localhost. For example, to access Grafana at http://192.168.56.100:3000:
+**Problem 1**: Receiving `Bad gateway` error when accessing the application at `myapp.local` using Minikube.
+
+**Solution 1**: Make sure that requests to myapp.local are not intercepted by nginx before tunneling. To ensure nginx is not listening on port 80, you can stop local nginx temporarily:
+
+```bash
+sudo nginx -s stop
+```
+
+After stopping local nginx, re-run Minikube tunnel:
+
+```bash
+minikube tunnel  # keep this terminal tab open for as long as you need to access myapp.local
+```
+
+---
+
+**Problem 2**: kubectl does not work from host, only from the ctrl node. Cannot access Prometheus/Grafana.
+
+**Solution 2**: Since kubectl still works on ctrl, just use ctrl's IP address instead of localhost. For example, to access Grafana at http://192.168.56.100:3000:
 
 ```bash
 vagrant ssh ctrl

--- a/RUBRIC.md
+++ b/RUBRIC.md
@@ -184,10 +184,10 @@ Excellent:
 
 ### Code Quality - Excellent
 
-- Non-standard [.pylintrc]()
+- Non-standard [.pylintrc](https://github.com/remla25-team12/model-training/blob/b73e69e97cd00173d992496e1df75cc0a8de5d3a/.pylintrc#L85)
 - No warnings (else our GitHub action for linting would fail)
 - Multiple linters: black and flake8 defined in [setup.cfg](https://github.com/remla25-team12/model-training/blob/main/setup.cfg)
-- Custom pylint rule for ML-Specific code smells: We relaxed the naming convention rules to accommodate commonly used variable names in ML pipelines, such as X, X_train, X_test, y, and y_pred.
+- [Custom pylint rule](https://github.com/remla25-team12/model-training/blob/b73e69e97cd00173d992496e1df75cc0a8de5d3a/.pylintrc#L236) for ML-Specific code smells: We relaxed the naming convention rules to accommodate commonly used variable names in ML pipelines, such as X, X_train, X_test, y, and y_pred.
 
 # A5 Istio Service Mesh
 
@@ -202,7 +202,7 @@ Excellent:
 
 ### Additional Use Case - Excellent
 
-- We fully realized rate limiting with Istio: maximum 10 requests globally and maximum 2 model queries (/predict endpoint) per minute.
+- We fully realized rate limiting with Istio: maximum 10 requests globally and maximum 2 model queries (/predict endpoint) per minute. Check our [README]() for rate limiting details.
 
 ### Continuous Experimentation - Excellent
 

--- a/RUBRIC.md
+++ b/RUBRIC.md
@@ -202,7 +202,7 @@ Excellent:
 
 ### Additional Use Case - Excellent
 
-- We fully realized rate limiting with Istio: maximum 10 requests globally and maximum 2 model queries (/predict endpoint) per minute. Check our [README]() for rate limiting details.
+- We fully realized rate limiting with Istio: maximum 10 requests globally and maximum 2 model queries (/predict endpoint) per minute. Check our [README](https://github.com/remla25-team12/operation/blob/main/README.md#rate-limiting) for rate limiting details.
 
 ### Continuous Experimentation - Excellent
 


### PR DESCRIPTION
We realized a problem with the Bad Gateway error when testing our minikube. The problem was that our local nginx server (outside Kubernetes/Minikube) is already listening on port 80, so requests to http://myapp.local/ are intercepted by that nginx, not by Istio via minikube tunnel.

The solution is to allow minikube tunnel (and Istio Ingress Gateway) to bind port 80 on localhost. To do this, we need to stop local nginx temporarily. To do this, we need to run the following command before tunneling:

sudo nginx -s stop

Our README is updated with this step and enhanced with some other final modifications. 

Also, add some more hyperlinks for our RUBRIC.md file based on the final additions to our repos.